### PR TITLE
Allow checking rank of user by ID

### DIFF
--- a/src/commands/levels/rank.js
+++ b/src/commands/levels/rank.js
@@ -1,7 +1,16 @@
 const RichEmbed = require('discord.js').RichEmbed;
 
-exports.run = async (bot, msg) => {
-    const user = msg.mentions.users.first() || msg.author;
+exports.run = async (bot, msg, args) => {
+    let user;
+    if (msg.mentions.users.first()) {
+        user = msg.mentions.users.first();
+    } else if (args.length === 1) {
+        user = bot.users.get(args[0]);
+    }
+
+    if (!user) {
+        user = msg.author;
+    }
 
     const data = await bot.managers.get('levels').getUserData(user.id);
 


### PR DESCRIPTION
The motivation for this is that I recently checked the rank of someone who was talking about their rank, and  I had to `@` mentioned them when thats not really what I wanted.